### PR TITLE
Use auto layout in view controller

### DIFF
--- a/tutorials/mpp-iOS-Android/native/KotlinIOS/KotlinIOS/ViewController.swift
+++ b/tutorials/mpp-iOS-Android/native/KotlinIOS/KotlinIOS/ViewController.swift
@@ -10,22 +10,21 @@ import UIKit
 import SharedCode
 
 
-
-
-
 class ViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 300, height: 21))
-        label.center = CGPoint(x: 160, y: 285)
-        label.textAlignment = .center
-        label.font = label.font.withSize(25)
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
         label.text = CommonKt.createApplicationScreenMessage()
+        label.font = UIFont.systemFont(ofSize: 42.0)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+
         view.addSubview(label)
+
+        label.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+        label.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        label.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
     }
-
-
 }
-


### PR DESCRIPTION
Move from springs and struts to [layout anchors](https://developer.apple.com/documentation/uikit/nslayoutanchor) (Auto Layout). This now matches the Android UI.

![Screen Shot 2019-05-10 at 3 20 59 PM](https://user-images.githubusercontent.com/5751156/57551540-446e8500-7337-11e9-83f5-1c64eb3cebe1.png)
