### PR TITLE
Fix misconfigured module description in dokka example

### DIFF
--- a/gradle/dokka/dokka-gradle-example/Module.md
+++ b/gradle/dokka/dokka-gradle-example/Module.md
@@ -1,4 +1,4 @@
-# Module dokka-gradle-example
+# Module Dokka Gradle Example
 
 This is an example of how you can write module documentation with Dokka.
 


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/32793002/92742619-19a79d00-f380-11ea-8b83-fa93df29edec.png)

After:
![obraz](https://user-images.githubusercontent.com/32793002/92742557-08f72700-f380-11ea-94ed-caf24e02bc1c.png)
